### PR TITLE
Ensure database connection closes in create_user

### DIFF
--- a/minmax_app/app/main.py
+++ b/minmax_app/app/main.py
@@ -660,24 +660,23 @@ def create_user(username: str, password: str, org_name: str, role: str) -> int:
     """
     salt = secrets.token_hex(16)
     password_hash = hash_password(password, salt)
-    conn = get_db_connection()
-    cur = conn.cursor()
-    # Ensure organization exists
-    cur.execute("SELECT id FROM organizations WHERE name = ?", (org_name,))
-    row = cur.fetchone()
-    if row:
-        org_id = row["id"]
-    else:
-        cur.execute("INSERT INTO organizations (name) VALUES (?)", (org_name,))
-        org_id = cur.lastrowid
-    # Insert user
-    cur.execute(
-        "INSERT INTO users (username, password_hash, salt, org_id, role) VALUES (?, ?, ?, ?, ?)",
-        (username, password_hash, salt, org_id, role),
-    )
-    user_id = cur.lastrowid
-    conn.commit()
-    conn.close()
+    with get_db_connection() as conn:
+        cur = conn.cursor()
+        # Ensure organization exists
+        cur.execute("SELECT id FROM organizations WHERE name = ?", (org_name,))
+        row = cur.fetchone()
+        if row:
+            org_id = row["id"]
+        else:
+            cur.execute("INSERT INTO organizations (name) VALUES (?)", (org_name,))
+            org_id = cur.lastrowid
+        # Insert user
+        cur.execute(
+            "INSERT INTO users (username, password_hash, salt, org_id, role) VALUES (?, ?, ?, ?, ?)",
+            (username, password_hash, salt, org_id, role),
+        )
+        user_id = cur.lastrowid
+        conn.commit()
     return user_id
 
 


### PR DESCRIPTION
## Summary
- Wrap `create_user` connection logic in a context manager to guarantee proper cleanup

## Testing
- `pytest`
- `python -m py_compile minmax_app/app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68914cdca0c083239a856916f30212e0